### PR TITLE
Build tool update

### DIFF
--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -201,7 +201,7 @@ if [ $DOCKER = "1" ]; then
 FROM $base_image
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN echo 'Acquire::http { Proxy "$MIRROR_BASE"; };' > /etc/apt/apt.conf.d/50cacher
+# RUN echo 'Acquire::http { Proxy "$MIRROR_BASE"; };' > /etc/apt/apt.conf.d/50cacher
 RUN apt-get update && apt-get --no-install-recommends -y install $addpkg
 
 RUN useradd -ms /bin/bash -U $DISTRO

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -88,7 +88,7 @@ if [ $# != 0 ] ; then
         DOCKER=1
         shift 1
         ;;
-      --docker-image-digest)
+      --docker-image-hash)
         DOCKER_IMAGE_HASH="$2"
         shift 2
         ;;
@@ -205,7 +205,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get --no-install-recommends -y install $addpkg
 
 RUN useradd -ms /bin/bash -U $DISTRO
-USER $DISTRO:$DISTRO
+RUN adduser $DISTRO sudo
+RUN echo "${DISTRO}:${DISTRO}" | chpasswd
+USER $DISTRO
 WORKDIR /home/$DISTRO
 
 CMD ["sleep", "infinity"]

--- a/bin/make-base-vm
+++ b/bin/make-base-vm
@@ -203,6 +203,9 @@ FROM $base_image
 ENV DEBIAN_FRONTEND=noninteractive
 # RUN echo 'Acquire::http { Proxy "$MIRROR_BASE"; };' > /etc/apt/apt.conf.d/50cacher
 RUN apt-get update && apt-get --no-install-recommends -y install $addpkg
+RUN apt-get install -y mingw-w64 g++-mingw-w64 
+RUN update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
+RUN update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
 
 RUN useradd -ms /bin/bash -U $DISTRO
 RUN adduser $DISTRO sudo


### PR DESCRIPTION
Updating the build tool to include mingw for windows builds as a default. This wont exactly be docker image agnostic but will resolve temporarily the build issues on windows.